### PR TITLE
RCL API Integration

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -12,4 +12,6 @@ OUTPUT_CHANNEL_DEV_ID=''
 DATA_PATH='data/'
 BUILD_PATH='dist/build'
 LOGGING_LEVEL='20'
+RCL_API_URL='https://retrocyclesleague.com'
+RCL_API_KEY=''
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,23 @@ Alternatively, you can use a process manager like [PM2](https://pm2.keymetrics.i
 
 The source is now using the Sapphire framework. Documentation can be found [here](https://www.sapphirejs.dev/)
 
+### RCL Queue API integration
+
+The `!add` command can push a queue join to the RCL dashboard API.
+
+- Configure:
+  - `RCL_API_URL` (example: `https://retrocyclesleague.com`)
+  - `RCL_API_KEY` (bot API key shared by dashboard owner)
+- Payload sent to `/api/queue/bot/join` includes:
+  - `source: "discord:{user_id}"`
+  - `username: "{discord_username}"`
+  - `playerName: "{discord_username}"` (compatibility field used by current dashboard API)
+
+Only supported playlists are forwarded to queue modes:
+- `fort` -> `fort`
+- `tst`, `tstplacement` -> `tst`
+- `sumo`, `sumobar`, `sumobarplacement` -> `sumo`
+
 ### Auto removal
 
 Auto removal from playlists has a default setting of 60 minutes, and warning after 50 minutes. This can be overwritten by setting environment variables `EXPIRE_AFTER_TIME_IN_MINUES` and `WARN_AFTER_TIME_IN_MINUES` respectively (i.e. `export EXPIRE_AFTER_TIME_IN_MINUES=30`) or adjusting your `.env`.

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -1,5 +1,6 @@
 import { Command, container } from "@sapphire/framework";
 import type { Message } from "discord.js";
+import { pushDiscordAddToQueueApi } from "../core/rclQueueApi";
 
 // Use this to disable commands like start in production environment
 const COMMAND_ENABLED = true;
@@ -50,13 +51,32 @@ export class AddCommand extends Command {
         const { author } = message;
         const content = message.content;
         const splitContent = content.split(" ");
-        const command = splitContent.shift();
+        splitContent.shift();
+        const requestedPlaylists =
+            splitContent.length > 0 ? [...new Set<string>(splitContent)] : ["fort", "tst"];
         if (splitContent.length > 0) {
-            const uniquePlaylists = new Set<string>(splitContent);
+            const uniquePlaylists = new Set<string>(requestedPlaylists);
             result = container.manager.addToPlaylists(uniquePlaylists, author);
         } else {
             result = container.manager.addToPlaylists(["fort", "tst"], author);
         }
+
+        const queueResult = await pushDiscordAddToQueueApi(
+            requestedPlaylists,
+            author.id,
+            author.username
+        );
+
+        if (queueResult.attempted > 0) {
+            if (queueResult.failedModes.length === 0) {
+                result += `\nQueue API synced: ${queueResult.successfulModes.join(", ")}`;
+            } else {
+                result += `\nQueue API partial sync: ${queueResult.successfulModes.join(
+                    ", "
+                )} (failed: ${queueResult.failedModes.map((f) => f.mode).join(", ")})`;
+            }
+        }
+
         container.logger.debug(
             `New !add message from ${author.username}: ${content} | (Result): ${result}`,
         );

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -28,6 +28,8 @@ let config = {
     LOGGING_LEVEL: process.env.LOGGING_LEVEL
         ? parseInt(process.env.LOGGING_LEVEL, 10)
         : 10,
+    RCL_API_URL: process.env.RCL_API_URL,
+    RCL_API_KEY: process.env.RCL_API_KEY,
 };
 
 const CLIENT_OPTIONS: ClientOptions = {

--- a/src/core/rclQueueApi.ts
+++ b/src/core/rclQueueApi.ts
@@ -1,0 +1,117 @@
+import { container } from "@sapphire/framework";
+import { config } from "../config/config";
+
+type QueueJoinRequest = {
+    mode: string;
+    discordId: string;
+    username: string;
+};
+
+type QueuePushResult = {
+    attempted: number;
+    successfulModes: string[];
+    failedModes: Array<{ mode: string; error: string }>;
+    skippedPlaylists: string[];
+};
+
+const PLAYLIST_TO_QUEUE_MODE: Record<string, string | undefined> = {
+    fort: "fort",
+    tst: "tst",
+    tstplacement: "tst",
+    sumo: "sumo",
+    sumobar: "sumo",
+    sumobarplacement: "sumo",
+};
+
+function normalizeApiUrl(url: string): string {
+    return url.replace(/\/+$/, "");
+}
+
+function getQueueModeFromPlaylist(playlist: string): string | undefined {
+    const normalized = playlist.toLowerCase();
+    return PLAYLIST_TO_QUEUE_MODE[normalized];
+}
+
+async function postQueueJoin({ mode, discordId, username }: QueueJoinRequest): Promise<void> {
+    if (!config.RCL_API_URL || !config.RCL_API_KEY) {
+        throw new Error("RCL_API_URL or RCL_API_KEY is missing");
+    }
+
+    const url = `${normalizeApiUrl(config.RCL_API_URL)}/api/queue/bot/join`;
+    const response = await fetch(url, {
+        method: "POST",
+        headers: {
+            "content-type": "application/json",
+            authorization: `Bearer ${config.RCL_API_KEY}`,
+        },
+        body: JSON.stringify({
+            mode,
+            // Keep both fields for forward/backward compatibility.
+            username,
+            playerName: username,
+            source: `discord:${discordId}`,
+        }),
+    });
+
+    if (!response.ok) {
+        const body = await response.text().catch(() => "");
+        throw new Error(`HTTP ${response.status}${body ? `: ${body}` : ""}`);
+    }
+}
+
+export async function pushDiscordAddToQueueApi(
+    playlists: Iterable<string>,
+    discordId: string,
+    username: string
+): Promise<QueuePushResult> {
+    if (!config.RCL_API_URL || !config.RCL_API_KEY) {
+        container.logger.debug("Queue API integration disabled (missing RCL_API_URL or RCL_API_KEY)");
+        return {
+            attempted: 0,
+            successfulModes: [],
+            failedModes: [],
+            skippedPlaylists: [],
+        };
+    }
+
+    const uniqueModes = new Set<string>();
+    const skippedPlaylists: string[] = [];
+
+    for (const playlist of playlists) {
+        const mode = getQueueModeFromPlaylist(playlist);
+        if (mode) {
+            uniqueModes.add(mode);
+        } else {
+            skippedPlaylists.push(playlist);
+        }
+    }
+
+    const successfulModes: string[] = [];
+    const failedModes: Array<{ mode: string; error: string }> = [];
+
+    for (const mode of uniqueModes) {
+        try {
+            await postQueueJoin({ mode, discordId, username });
+            successfulModes.push(mode);
+        } catch (error) {
+            failedModes.push({
+                mode,
+                error: error instanceof Error ? error.message : "Unknown queue API error",
+            });
+        }
+    }
+
+    if (failedModes.length > 0) {
+        container.logger.warn(
+            `Queue API failures for ${username} (${discordId}): ${JSON.stringify(failedModes)}`
+        );
+    }
+
+    return {
+        attempted: uniqueModes.size,
+        successfulModes,
+        failedModes,
+        skippedPlaylists,
+    };
+}
+


### PR DESCRIPTION
### RCL Queue API integration

The `!add` command can push a queue join to the RCL dashboard API.

- Configure:
  - `RCL_API_URL` (example: `https://retrocyclesleague.com`)
  - `RCL_API_KEY` (bot API key shared by dashboard owner)
- Payload sent to `/api/queue/bot/join` includes:
  - `source: "discord:{user_id}"`
  - `username: "{discord_username}"`
  - `playerName: "{discord_username}"` (compatibility field used by current dashboard API)

Only supported playlists are forwarded to queue modes:
- `fort` -> `fort`
- `tst`, `tstplacement` -> `tst`
- `sumo`, `sumobar`, `sumobarplacement` -> `sumo`